### PR TITLE
Security: bump @modelcontextprotocol/sdk + @anthropic-ai/sdk, harden data loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "raven-mcp",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raven-mcp",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.24.0"
       },
       "bin": {
         "raven-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.95.1",
         "@types/node": "^22.0.0",
         "resend": "^6.10.0",
         "tsx": "^4.19.0",
@@ -25,13 +25,14 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "version": "0.95.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.1.tgz",
+      "integrity": "sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -952,12 +953,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1148,9 +1149,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1199,9 +1200,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raven-mcp",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "mcpName": "ai.ravenmcp/raven-mcp",
   "description": "Design intelligence MCP server — principles, patterns, tokens, content systems, research methods, service design, and brand guidance for AI-generated UI. Now with research, service design (with HTML blueprint generation), and brand/visual design layers.",
   "type": "module",
@@ -26,15 +26,19 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/sdk": "^0.95.1",
     "@types/node": "^22.0.0",
     "resend": "^6.10.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "hono": "^4.12.18",
+    "express-rate-limit": "^8.5.1"
   },
   "keywords": [
     "mcp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,21 @@ function loadJsonDir<T>(dir: string): T[] {
   var files = readdirSync(dir).filter(f => f.endsWith(".json"));
   var results: T[] = [];
   for (var file of files) {
-    var raw = readFileSync(join(dir, file), "utf-8");
-    var parsed = JSON.parse(raw);
+    var fullPath = join(dir, file);
+    var raw: string;
+    try {
+      raw = readFileSync(fullPath, "utf-8");
+    } catch (err) {
+      console.error("[raven] skipped " + fullPath + " (read failed: " + (err as Error).message + ")");
+      continue;
+    }
+    var parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      console.error("[raven] skipped " + fullPath + " (invalid JSON: " + (err as Error).message + ")");
+      continue;
+    }
     if (Array.isArray(parsed)) {
       results = results.concat(parsed);
     } else {
@@ -790,7 +803,9 @@ try {
   if (existsSync(pkgPath)) {
     PKG_VERSION = JSON.parse(readFileSync(pkgPath, "utf-8")).version || "0.0.0";
   }
-} catch {}
+} catch (_err) {
+  // Best-effort version read; falls back to "0.0.0" if package.json is unavailable.
+}
 
 var pendingUpdateNotice: string | null = null;
 var noticeShown: boolean = false;
@@ -829,7 +844,7 @@ async function checkForUpdate(): Promise<void> {
         (cmp === "newer-major" ? "major" : "minor") + " bump). " + installHint;
       console.error(pendingUpdateNotice);
     }
-  } catch {
+  } catch (_err) {
     // Offline, blocked, rate-limited, anything — stay silent.
   }
 }
@@ -963,7 +978,7 @@ function extractInsight(toolName: string, input: any, output: any): any {
       default:
         insight = {};
     }
-  } catch {
+  } catch (_err) {
     insight = { extract_failed: true };
   }
   return insight;
@@ -980,7 +995,7 @@ function logUsage(toolName: string, input: any, output: any, elapsedMs: number):
     };
     mkdirSync(dirname(USAGE_LOG_PATH), { recursive: true });
     appendFileSync(USAGE_LOG_PATH, JSON.stringify(entry) + "\n", "utf-8");
-  } catch {
+  } catch (_err) {
     // Never let logging disrupt a real tool call.
   }
 }
@@ -1000,10 +1015,12 @@ function readUsageSince(daysBack: number): any[] {
       try {
         var e = JSON.parse(line);
         if (new Date(e.t).getTime() >= cutoff) out.push(e);
-      } catch {}
+      } catch (_parseErr) {
+        // Corrupt single line — skip and continue reading the rest of the log.
+      }
     }
     return out;
-  } catch {
+  } catch (_err) {
     return [];
   }
 }
@@ -1063,8 +1080,8 @@ function maybeComputeDailyDigest(): void {
     if (topWarnings.length) parts.push("recurring " + topWarnings.join(", "));
     parts.push('ask "raven_reflect" for full breakdown');
     pendingDailyDigest = parts.join(" · ");
-  } catch {
-    // Silent.
+  } catch (_err) {
+    // Silent — digest is best-effort and never blocks tool calls.
   }
 }
 


### PR DESCRIPTION
## Summary

Patches all 5 findings from the MCP marketplace security scan.

**Supply-chain CVEs** (4 high/medium → 0):
- `@modelcontextprotocol/sdk` ^1.12.1 → ^1.29.0
  - CVE-2026-25536 cross-client transport reuse (GHSA-345p-7cg4-v4c7)
  - CVE-2026-0621 ReDoS (GHSA-8r9q-7v3j-jr4g)
  - CVE-2025-66414 DNS rebinding (GHSA-w48q-cv73-mx4w) — note: stdio transport doesn't expose this surface, but bumped for full clearance
- `@anthropic-ai/sdk` ^0.90.0 → ^0.95.1
  - CVE-2026-41686 insecure default file permissions in Filesystem Memory Tool (GHSA-p7fg-763f-g4gf) — only used by helper scripts
- Added `overrides` for transitive `hono` ^4.12.18 + `express-rate-limit` ^8.5.1 (XSS, body-limit bypass, ip-address advisory — caught by `npm audit`, not in marketplace report but worth fixing)

**Code-level finding** ("Broad exception handling in data loading"):
- `loadJsonDir`: per-file try/catch around `readFileSync` and `JSON.parse` so a malformed/unreadable data file logs a stderr warning and is skipped, rather than crashing the server at module init.
- Bound error variables on bare `} catch {}` blocks in update check, usage log, and daily digest with a one-line comment documenting why each is silent.

**Version**: 1.3.3 → 1.3.4

## Verification

- [x] `npm audit` reports **0 vulnerabilities**
- [x] `npm run build` (TypeScript) passes
- [x] MCP `initialize` handshake + `tools/list` smoke test passes against the rebuilt `dist/index.js`
- [x] Server reports `v1.3.4` on stdio handshake

## Test plan

- [ ] Reviewer runs `npm install && npm run build && npm audit` to reconfirm 0 vulns
- [ ] After merge: run `bash scripts/release.sh` (or manual `npm publish`) to ship v1.3.4 to the registry — the marketplace scan only re-clears once the published artifact is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)