### PR TITLE
Add audit_responsive_visibility + audit_contrast tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ The public web changelog at [ravenmcp.ai/changelog.html](https://ravenmcp.ai/cha
 - `audit_page` now accepts an optional `containerMaxWidth` (your design system's canonical content-container width, in px). When set, the `responsive/max-width` check flags content containers that **diverge** from your token — too narrow or too wide — instead of a generic 1200px heuristic. Catches an off-system page (e.g. a `max-w-3xl` 768px container in a 1152px system) that the old check passed clean. With no token passed, behavior is unchanged. (#9)
 
 ### Added
-- `src/audit-container.ts` — side-effect-free container-width audit helper, unit-testable in isolation.
+- `audit_responsive_visibility` — render a page at multiple breakpoints (default: 390/768/1440/2160px) and flag content elements visible on desktop but hidden on mobile. Categorises each flagged element as likely-oversight (content vanishing on mobile) vs intentional (decorative). Catches responsive-hiding bugs that only surface on real devices. Detects hiding via computed styles (display:none/visibility:hidden/opacity:0/zero-size) and Tailwind responsive classes (hidden md:block). Reports selector, hiding class, visibility per breakpoint, and category for each flagged row.
+- `audit_contrast` — compute WCAG 2.1 contrast ratios for every text element on a rendered page and report AA/AAA pass-fail. Returns per-element ratio, delta-to-pass for failures, and aggregated failure count. WCAG math is exact: linearised luminance, 21 for black-on-white, 4.5:1 / 3:1 large for AA, 7:1 / 4.5:1 large for AAA. Replaces manual eyedropper + ratio calculation.
+- `src/responsive.ts` — headless renderer and categoriser for responsive-visibility audits.
+- `src/contrast.ts` — pure WCAG math (parseColor, relativeLuminance, contrastRatio) plus headless renderer for contrast audits. Exports testable functions so contrast scoring can be unit-tested in isolation.
 - `src/capture.ts` — headless Chromium renderer for `audit_page`. New `url` parameter (optional) enables live rendering with Playwright: render the page, optionally scroll to bottom and settle IntersectionObserver / whileInView reveals, play preload=none videos, then audit the live DOM. Includes video-artifact detection: flags `<video preload="none">` elements that render blank (readyState < 2), helping catch unloaded media without false positives on reveal-on-scroll pages. Backwards-compatible: calling `audit_page` with `html` only (no `url`) behaves identically to prior versions. Playwright binary is optional; if missing, a clear instruction guides setup via `npx playwright install chromium`.
+- `src/audit-container.ts` — side-effect-free container-width audit helper, unit-testable in isolation.
 
 ## [1.4.0] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ cd raven-mcp && npm install && npm run build
 | `get_brand_system` | Get a full system styled like a well-known brand |
 | `audit_page` | Audit HTML/CSS against Raven's quality standards — pass `html` for static audit, or `url` to render headless with optional `scroll_settle` (scroll to bottom + settle reveals) and `viewport` parameters; `containerMaxWidth` makes container checks token-aware |
 | `audit_layout` | Evaluate visual rhythm, alignment, and optical balance |
+| `audit_responsive_visibility` | Render a URL at multiple breakpoints and flag content elements that are visible on desktop but hidden on mobile (display:none/opacity:0/zero-size) — categorises each as likely-oversight (content vanishing on mobile) vs intentional (decorative) |
+| `audit_contrast` | Compute WCAG contrast ratios for every text element on a rendered page and report AA (4.5:1 / 3:1 large) and AAA pass-fail per element, with delta-to-pass for failures |
 | `audit_swiftui` | Audit SwiftUI source against Apple HIG — Dynamic Type, semantic colors, 44pt targets, 4/8pt spacing, AccentColor |
 | `audit_ios_screen` | Score a rendered iOS screen from an accessibility/view-hierarchy snapshot — 44pt targets + contrast + rhythm, in points |
 | `audit_ios_privacy` | Audit Info.plist (or Expo app.json) /PRIVACY.md/entitlements/source — usage-string honesty, ATS, Android permissions, bundled secrets, undisclosed default data-egress |
@@ -128,6 +130,29 @@ Anyone building a React Native or Expo app gets the same treatment. RN renders t
 - **`audit_ios_privacy`** also accepts an Expo **`app_json`** — it audits `expo.ios.infoPlist`, Android permissions, plugins, and scans `expo.extra`/config for secrets and Google API keys.
 
 **One command:** `node scripts/rn-audit.mjs <app-dir> [--snapshot snap.json] [--md report.md]` discovers screens + `app.json` (reading `userInterfaceStyle` so dark-only apps aren't false-flagged) and runs everything.
+
+## Responsive visibility audits
+
+`audit_responsive_visibility` renders a page at multiple breakpoints (default: 390px mobile, 768px tablet, 1440px desktop, 2160px ultra-wide) and flags content elements that are visible on desktop but hidden on mobile — catching the "vanishes on mobile" bug class. Each flagged element is categorised as **likely-oversight** (content that shouldn't be hidden) or **intentional** (decorative elements). Detects hiding via CSS (`hidden`, `display:none`, `opacity:0`, `visibility:hidden`) and responsive Tailwind classes (`hidden md:block`, etc.).
+
+**Usage:**
+- `audit_responsive_visibility(url)` — render at default breakpoints and flag mismatches.
+- `audit_responsive_visibility(url, [390, 768, 1440])` — custom breakpoints.
+- Optional `viewportHeight` (default: 900px) for tall content.
+
+Returns flagged elements with selector, hiding class, visibility at each breakpoint, and category.
+
+## Contrast audits
+
+`audit_contrast` computes WCAG contrast ratios for every text element on a rendered page, reporting AA (4.5:1 normal text, 3:1 large) and AAA (7:1 normal, 4.5:1 large) pass-fail. Useful for catching small-text / low-contrast pairs that a screenshot eyedropper would catch manually — Raven replaces the math.
+
+**Usage:**
+- `audit_contrast(url)` — render a live page and audit all text.
+- `audit_contrast(dom_snapshot: [{ selector, color, bgColor, fontPx?, bold?, text? }])` — audit a pre-captured snapshot (useful for dynamic or cookie-protected pages).
+
+Returns all text elements scored, failures highlighted with delta-to-pass, and a summary of AA/AAA failure count.
+
+**WCAG math:** Contrast ratio uses linearised luminance (WCAG 2.1 § 1.4.3) — black-on-white is exactly 21, white-on-black is exactly 21. Large text (18.66pt+ bold or 24pt+) needs only 3:1 / 4.5:1 AAA; regular text needs 4.5:1 / 7:1.
 
 ## Headless browser audits
 

--- a/manifest.json
+++ b/manifest.json
@@ -109,6 +109,14 @@
       "description": "Evaluate visual rhythm, alignment, and optical balance of a rendered page"
     },
     {
+      "name": "audit_responsive_visibility",
+      "description": "Render a URL at multiple breakpoints and flag content elements that are visible on desktop but hidden on mobile"
+    },
+    {
+      "name": "audit_contrast",
+      "description": "Compute WCAG contrast ratios for every text element on a rendered page and report AA/AAA pass-fail"
+    },
+    {
       "name": "list_content_systems",
       "description": "Browse available brand voice & tone systems (Mailchimp, GOV.UK, Shopify Polaris, Atlassian)"
     },

--- a/src/contrast.ts
+++ b/src/contrast.ts
@@ -1,0 +1,366 @@
+/**
+ * contrast.ts — WCAG contrast audit module for audit_contrast tool.
+ * Pure WCAG math + Playwright-backed page audit.
+ * No new npm dependencies required.
+ */
+
+import { CaptureUnavailableError } from "./capture.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ContrastRow = {
+  selector: string;
+  text: string;
+  foreground: string;
+  background: string;
+  fontPx: number;
+  bold: boolean;
+  large: boolean;
+  ratio: number;
+  aa: boolean;
+  aaa: boolean;
+  required_aa: number;
+  delta_to_aa: number;
+};
+
+export type ContrastResult = {
+  url?: string;
+  total_text_elements: number;
+  rows: ContrastRow[];
+  aa_failures: ContrastRow[];
+  aa_fail_count: number;
+  warnings: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Pure WCAG math — exported for tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a CSS colour string into [r, g, b, a] where r/g/b ∈ 0-255, a ∈ 0-1.
+ * Handles: #RGB, #RRGGBB, #RGBA, #RRGGBBAA, rgb(), rgba(), black, white, transparent.
+ * Unknown/unparseable → [0, 0, 0, 1] (opaque black, safe fallback).
+ */
+export function parseColor(css: string): [number, number, number, number] {
+  const s = css.trim().toLowerCase();
+
+  if (s === "black") return [0, 0, 0, 1];
+  if (s === "white") return [255, 255, 255, 1];
+  if (s === "transparent") return [0, 0, 0, 0];
+
+  // #hex
+  if (s.startsWith("#")) {
+    const h = s.slice(1);
+    if (h.length === 3) {
+      const r = parseInt(h[0] + h[0], 16);
+      const g = parseInt(h[1] + h[1], 16);
+      const b = parseInt(h[2] + h[2], 16);
+      return [r, g, b, 1];
+    }
+    if (h.length === 4) {
+      const r = parseInt(h[0] + h[0], 16);
+      const g = parseInt(h[1] + h[1], 16);
+      const b = parseInt(h[2] + h[2], 16);
+      const a = parseInt(h[3] + h[3], 16) / 255;
+      return [r, g, b, a];
+    }
+    if (h.length === 6) {
+      const r = parseInt(h.slice(0, 2), 16);
+      const g = parseInt(h.slice(2, 4), 16);
+      const b = parseInt(h.slice(4, 6), 16);
+      return [r, g, b, 1];
+    }
+    if (h.length === 8) {
+      const r = parseInt(h.slice(0, 2), 16);
+      const g = parseInt(h.slice(2, 4), 16);
+      const b = parseInt(h.slice(4, 6), 16);
+      const a = parseInt(h.slice(6, 8), 16) / 255;
+      return [r, g, b, a];
+    }
+    return [0, 0, 0, 1];
+  }
+
+  // rgb() / rgba()
+  const rgbaMatch = s.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/);
+  if (rgbaMatch) {
+    const r = Math.round(parseFloat(rgbaMatch[1]));
+    const g = Math.round(parseFloat(rgbaMatch[2]));
+    const b = Math.round(parseFloat(rgbaMatch[3]));
+    const a = rgbaMatch[4] !== undefined ? parseFloat(rgbaMatch[4]) : 1;
+    return [r, g, b, a];
+  }
+
+  return [0, 0, 0, 1];
+}
+
+/**
+ * Linearise a single 0-255 channel to the sRGB linear scale.
+ */
+function linearise(c: number): number {
+  const c01 = c / 255;
+  return c01 <= 0.03928 ? c01 / 12.92 : Math.pow((c01 + 0.055) / 1.055, 2.4);
+}
+
+/**
+ * WCAG relative luminance for an [r,g,b] triple (0-255).
+ */
+export function relativeLuminance(rgb: [number, number, number]): number {
+  const R = linearise(rgb[0]);
+  const G = linearise(rgb[1]);
+  const B = linearise(rgb[2]);
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+/**
+ * WCAG contrast ratio between two [r,g,b] triples (0-255). Range: 1..21.
+ * contrastRatio([0,0,0], [255,255,255]) === 21 (±0.01).
+ */
+export function contrastRatio(
+  fg: [number, number, number],
+  bg: [number, number, number]
+): number {
+  const L1 = relativeLuminance(fg);
+  const L2 = relativeLuminance(bg);
+  return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+}
+
+// ---------------------------------------------------------------------------
+// Composite alpha over white
+// ---------------------------------------------------------------------------
+
+function compositeOverWhite(
+  r: number,
+  g: number,
+  b: number,
+  a: number
+): [number, number, number] {
+  const rOut = Math.round(r * a + 255 * (1 - a));
+  const gOut = Math.round(g * a + 255 * (1 - a));
+  const bOut = Math.round(b * a + 255 * (1 - a));
+  return [rOut, gOut, bOut];
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot audit (pure — no Playwright needed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Score a pre-collected snapshot of elements. No browser required.
+ */
+export function auditContrastSnapshot(
+  elements: Array<{
+    selector: string;
+    color: string;
+    bgColor: string;
+    fontPx?: number;
+    bold?: boolean;
+    text?: string;
+  }>
+): ContrastResult {
+  const warnings: string[] = [];
+  const rows: ContrastRow[] = [];
+
+  for (const el of elements) {
+    const [fr, fg, fb, fa] = parseColor(el.color);
+    const [br, bg, bb, ba] = parseColor(el.bgColor);
+
+    // Composite fg over white if semi-transparent
+    const fgRgb: [number, number, number] =
+      fa < 1 ? compositeOverWhite(fr, fg, fb, fa) : [fr, fg, fb];
+
+    // Composite bg over white if semi-transparent
+    const bgRgb: [number, number, number] =
+      ba < 1 ? compositeOverWhite(br, bg, bb, ba) : [br, bg, bb];
+
+    const fontPx = el.fontPx ?? 16;
+    const bold = el.bold ?? false;
+    const large = fontPx >= 24 || (fontPx >= 18.66 && bold);
+    const required_aa = large ? 3 : 4.5;
+    const required_aaa = large ? 4.5 : 7;
+
+    const ratio = contrastRatio(fgRgb, bgRgb);
+    const aa = ratio >= required_aa;
+    const aaa = ratio >= required_aaa;
+    const delta_to_aa = Math.max(0, required_aa - ratio);
+
+    rows.push({
+      selector: el.selector,
+      text: el.text ?? "",
+      foreground: el.color,
+      background: el.bgColor,
+      fontPx,
+      bold,
+      large,
+      ratio: Math.round(ratio * 100) / 100,
+      aa,
+      aaa,
+      required_aa,
+      delta_to_aa: Math.round(delta_to_aa * 100) / 100,
+    });
+  }
+
+  const aa_failures = rows.filter((r) => !r.aa);
+
+  return {
+    total_text_elements: rows.length,
+    rows,
+    aa_failures,
+    aa_fail_count: aa_failures.length,
+    warnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// URL audit (Playwright)
+// ---------------------------------------------------------------------------
+
+const ELEMENT_CAP = 600;
+
+/**
+ * Render a URL in headless Chromium, extract all visible text elements with
+ * their computed colours, then score them with auditContrastSnapshot.
+ */
+export async function auditContrastUrl(
+  url: string,
+  opts?: { viewport?: { w: number; h: number }; timeoutMs?: number }
+): Promise<ContrastResult> {
+  let chromium: import("playwright").BrowserType;
+  try {
+    const pw = await import("playwright");
+    chromium = pw.chromium;
+  } catch {
+    throw new CaptureUnavailableError(
+      "Playwright chromium not available. Run: npx playwright install chromium"
+    );
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const warnings: string[] = [];
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewportSize({
+      width: opts?.viewport?.w ?? 1440,
+      height: opts?.viewport?.h ?? 900,
+    });
+    await page.goto(url, {
+      waitUntil: "load",
+      timeout: opts?.timeoutMs ?? 30000,
+    });
+
+    // Collect raw element data from the page
+    type RawEl = {
+      selector: string;
+      color: string;
+      bgColor: string;
+      fontPx: number;
+      bold: boolean;
+      text: string;
+    };
+
+    const raw: RawEl[] = await page.evaluate((cap: number) => {
+      const results: RawEl[] = [];
+
+      /**
+       * Build a stable selector for an element — prefer data-testid / id,
+       * fall back to tag + nth-of-type.
+       */
+      function stableSelector(el: Element): string {
+        const testid = el.getAttribute("data-testid");
+        if (testid) return `[data-testid="${testid}"]`;
+        const id = el.getAttribute("id");
+        if (id) return `#${id}`;
+        const tag = el.tagName.toLowerCase();
+        const parent = el.parentElement;
+        if (parent) {
+          const siblings = Array.from(parent.children).filter(
+            (c) => c.tagName === el.tagName
+          );
+          const idx = siblings.indexOf(el) + 1;
+          return `${stableSelector(parent)} > ${tag}:nth-of-type(${idx})`;
+        }
+        return tag;
+      }
+
+      /**
+       * Walk ancestors to find the effective opaque background colour.
+       * Returns a CSS colour string.
+       */
+      function effectiveBgColor(el: Element): string {
+        let node: Element | null = el;
+        while (node) {
+          const style = window.getComputedStyle(node);
+          const bg = style.backgroundColor;
+          if (bg && bg !== "transparent" && bg !== "rgba(0, 0, 0, 0)") {
+            // Check if it has meaningful alpha
+            const m = bg.match(/rgba?\([\d.,\s]+,\s*([\d.]+)\)/);
+            if (!m || parseFloat(m[1]) > 0) {
+              return bg;
+            }
+          }
+          node = node.parentElement;
+        }
+        return "rgb(255, 255, 255)"; // default white
+      }
+
+      /**
+       * Check whether an element is visible (non-zero rect, not hidden).
+       */
+      function isVisible(el: Element): boolean {
+        const style = window.getComputedStyle(el);
+        if (style.display === "none" || style.visibility === "hidden") return false;
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      }
+
+      /**
+       * Check whether an element has a direct non-empty text node child.
+       */
+      function hasDirectText(el: Element): boolean {
+        for (let i = 0; i < el.childNodes.length; i++) {
+          const node = el.childNodes[i];
+          if (node.nodeType === Node.TEXT_NODE && node.textContent && node.textContent.trim().length > 0) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      const allElements = document.querySelectorAll("*");
+      for (let i = 0; i < allElements.length; i++) {
+        if (results.length >= cap) break;
+        const el = allElements[i];
+        if (!hasDirectText(el)) continue;
+        if (!isVisible(el)) continue;
+
+        const style = window.getComputedStyle(el);
+        const color = style.color || "rgb(0,0,0)";
+        const bgColor = effectiveBgColor(el);
+        const fontPx = parseFloat(style.fontSize) || 16;
+        const fw = style.fontWeight;
+        const bold = parseInt(fw) >= 600 || fw === "bold";
+        const text = (el.textContent || "").trim().slice(0, 60);
+        const selector = stableSelector(el);
+
+        results.push({ selector, color, bgColor, fontPx, bold, text });
+      }
+
+      return results;
+    }, ELEMENT_CAP);
+
+    if (raw.length >= ELEMENT_CAP) {
+      warnings.push(
+        `Element count capped at ${ELEMENT_CAP}. Some text elements were not audited.`
+      );
+    }
+
+    const result = auditContrastSnapshot(raw);
+    result.url = url;
+    result.warnings.push(...warnings);
+    return result;
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { auditContainerWidth } from "./audit-container.js";
 import { capturePage, CaptureUnavailableError, annotateVideoArtifacts } from "./capture.js";
+import { captureResponsiveVisibility } from "./responsive.js";
+import { auditContrastUrl, auditContrastSnapshot } from "./contrast.js";
 
 // ── Path setup ──────────────────────────────────────────────────────
 
@@ -2462,6 +2464,66 @@ server.tool(
         text: JSON.stringify(result, null, 2)
       }]
     };
+  }
+);
+
+// ── Tool 11b: audit_responsive_visibility ──────────────────────────
+
+server.tool(
+  "audit_responsive_visibility",
+  "Render a URL at multiple breakpoints and flag content elements that are visible on desktop but hidden on mobile (display:none / opacity:0 / visibility:hidden / zero-size). Categorises each flag as 'likely-oversight' (content that vanishes on mobile — the hidden-on-mobile content bug) vs 'intentional' (decorative). Returns a table of selector / hiding-class / mobile-visible / desktop-visible / category. Requires headless chromium.",
+  {
+    url: z.string().describe("URL to render (http/https or file://)"),
+    breakpoints: z.array(z.number()).optional().describe("Viewport widths in px. Default [390, 768, 1440, 2160]"),
+    viewportHeight: z.number().optional().describe("Render height in px. Default 900")
+  },
+  async function({ url, breakpoints, viewportHeight }) {
+    try {
+      var rv = await captureResponsiveVisibility(url, breakpoints, { viewportHeight: viewportHeight });
+      return { content: [{ type: "text" as const, text: JSON.stringify(rv, null, 2) }] };
+    } catch (error) {
+      if (error instanceof CaptureUnavailableError) {
+        return { content: [{ type: "text" as const, text: "audit_responsive_visibility needs headless chromium. Run: npx playwright install chromium" }] };
+      }
+      throw error;
+    }
+  }
+);
+
+// ── Tool 11c: audit_contrast ───────────────────────────────────────
+
+server.tool(
+  "audit_contrast",
+  "Compute WCAG contrast ratios for every text element on a rendered page (pass url) or from a supplied dom_snapshot. Reports AA (4.5:1 normal, 3:1 large) and AAA pass/fail per element and surfaces failing pairs with selector, ratio, and delta-to-pass — replacing manual eyedropper + ratio math.",
+  {
+    url: z.string().optional().describe("URL to render and measure (http/https or file://)"),
+    dom_snapshot: z.array(z.object({
+      selector: z.string(),
+      color: z.string(),
+      bgColor: z.string(),
+      fontPx: z.number().optional(),
+      bold: z.boolean().optional(),
+      text: z.string().optional()
+    })).optional().describe("Pre-collected text elements to score without rendering"),
+    screenshot: z.string().optional().describe("Optional base64 PNG for caller reference; ratios are computed from the DOM, not pixels")
+  },
+  async function({ url, dom_snapshot, screenshot }) {
+    if (url !== undefined && url !== null) {
+      try {
+        var ct = await auditContrastUrl(url);
+        return { content: [{ type: "text" as const, text: JSON.stringify(ct, null, 2) }] };
+      } catch (error) {
+        if (error instanceof CaptureUnavailableError) {
+          return { content: [{ type: "text" as const, text: "audit_contrast url mode needs headless chromium. Run: npx playwright install chromium — or pass a dom_snapshot instead." }] };
+        }
+        throw error;
+      }
+    }
+    if (dom_snapshot !== undefined && dom_snapshot !== null) {
+      var ctSnap = auditContrastSnapshot(dom_snapshot);
+      return { content: [{ type: "text" as const, text: JSON.stringify(ctSnap, null, 2) }] };
+    }
+    return { content: [{ type: "text" as const, text: "Provide either url (render + measure) or dom_snapshot (score supplied elements). Each dom_snapshot element: { selector, color, bgColor, fontPx?, bold?, text? }." }] };
   }
 );
 

--- a/src/responsive.ts
+++ b/src/responsive.ts
@@ -1,0 +1,331 @@
+/**
+ * responsive.ts — audit_responsive_visibility implementation
+ * Renders a URL at multiple breakpoints and flags content elements
+ * that are visible on desktop but hidden on mobile.
+ */
+
+import { CaptureUnavailableError } from "./capture.js";
+
+export type VisibilityRow = {
+  selector: string;
+  hidingClass: string | null;
+  isContent: boolean;
+  isDecorative: boolean;
+  visibleAt: { breakpoint: number; visible: boolean }[];
+  mobileVisible: boolean;
+  desktopVisible: boolean;
+  category: "intentional" | "likely-oversight";
+};
+
+export type ResponsiveVisibilityResult = {
+  url: string;
+  breakpoints: number[];
+  flagged: VisibilityRow[];
+  flagged_count: number;
+  likely_oversight_count: number;
+  warnings: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Regex patterns used in page.evaluate (serialised as strings) and host-side
+// ---------------------------------------------------------------------------
+
+const HIDING_CLASS_RE =
+  /(?:(?:sm|md|lg|xl|2xl):hidden)|(?:hidden\s+(?:sm|md|lg|xl|2xl):(?:block|flex|grid|inline|inline-block|table))/;
+
+const DECORATIVE_CLASS_RE =
+  /(decoration|divider|spacer|ornament|glow|blur|gradient|accent|bg-)(\s|$)/;
+
+// ---------------------------------------------------------------------------
+// Helper: build a stable unique CSS selector for an element
+// ---------------------------------------------------------------------------
+
+function buildSelector(el: Element): string {
+  if (el.id) {
+    return `#${CSS.escape(el.id)}`;
+  }
+
+  const parts: string[] = [];
+  let node: Element | null = el;
+
+  while (node && node !== document.documentElement) {
+    const current: Element = node;
+    const parent = current.parentElement;
+    if (!parent) break;
+
+    const tag = current.tagName.toLowerCase();
+    const siblings = Array.from(parent.children).filter(
+      (c) => c.tagName === current.tagName
+    );
+
+    if (siblings.length === 1) {
+      parts.unshift(tag);
+    } else {
+      const idx = siblings.indexOf(current) + 1;
+      parts.unshift(`${tag}:nth-of-type(${idx})`);
+    }
+
+    if (parent === document.body) {
+      parts.unshift("body");
+      break;
+    }
+
+    node = parent;
+  }
+
+  return parts.join(" > ") || el.tagName.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function captureResponsiveVisibility(
+  url: string,
+  breakpoints?: number[],
+  opts?: { viewportHeight?: number; timeoutMs?: number }
+): Promise<ResponsiveVisibilityResult> {
+  const bps = (breakpoints && breakpoints.length > 0 ? [...breakpoints] : [390, 768, 1440, 2160]).sort(
+    (a, b) => a - b
+  );
+  const viewportHeight = opts?.viewportHeight ?? 900;
+  const timeoutMs = opts?.timeoutMs ?? 30_000;
+
+  const warnings: string[] = [];
+
+  // Lazy playwright import
+  let playwright: typeof import("playwright");
+  try {
+    playwright = await import("playwright");
+  } catch {
+    throw new CaptureUnavailableError(
+      "Playwright chromium not available. Run: npx playwright install chromium"
+    );
+  }
+
+  let browser: import("playwright").Browser | null = null;
+
+  try {
+    try {
+      browser = await playwright.chromium.launch({ headless: true });
+    } catch {
+      throw new CaptureUnavailableError(
+        "Playwright chromium not available. Run: npx playwright install chromium"
+      );
+    }
+
+    const page = await browser.newPage();
+    await page.setViewportSize({ width: bps[0], height: viewportHeight });
+    await page.goto(url, { waitUntil: "load", timeout: timeoutMs });
+
+    // ----- Step 1: collect candidate elements (at initial viewport) -----
+    type CandidateMeta = {
+      selector: string;
+      hidingClass: string | null;
+      isDecorative: boolean;
+      isContent: boolean;
+      className: string;
+    };
+
+    const candidateMetas: CandidateMeta[] = await page.evaluate(
+      ({
+        hidingClassReStr,
+        decorativeClassReStr,
+      }: {
+        hidingClassReStr: string;
+        decorativeClassReStr: string;
+      }) => {
+        const hidingRe = new RegExp(hidingClassReStr);
+        const decorativeRe = new RegExp(decorativeClassReStr);
+
+        const CONTENT_SELECTOR =
+          "h1,h2,h3,h4,h5,h6,p,li,blockquote,figcaption,[data-lede]";
+
+        function buildSel(el: Element): string {
+          if (el.id) {
+            return "#" + CSS.escape(el.id);
+          }
+          const parts: string[] = [];
+          let node: Element | null = el;
+          while (node && node !== document.documentElement) {
+            const current: Element = node;
+            const parent = current.parentElement;
+            if (!parent) break;
+            const tag = current.tagName.toLowerCase();
+            const siblings = Array.from(parent.children).filter(
+              (c) => c.tagName === current.tagName
+            );
+            if (siblings.length === 1) {
+              parts.unshift(tag);
+            } else {
+              const idx = siblings.indexOf(current) + 1;
+              parts.unshift(tag + ":nth-of-type(" + idx + ")");
+            }
+            if (parent === document.body) {
+              parts.unshift("body");
+              break;
+            }
+            node = parent;
+          }
+          return parts.join(" > ") || el.tagName.toLowerCase();
+        }
+
+        const seen = new Set<Element>();
+        const results: Array<{
+          selector: string;
+          hidingClass: string | null;
+          isDecorative: boolean;
+          isContent: boolean;
+          className: string;
+        }> = [];
+
+        // Content candidates
+        document.querySelectorAll(CONTENT_SELECTOR).forEach((el) => {
+          if (!seen.has(el)) seen.add(el);
+        });
+
+        // Additionally: any element with a tailwind responsive-hide class pattern
+        document.querySelectorAll("*").forEach((el) => {
+          const cn = (el as HTMLElement).className;
+          if (typeof cn === "string" && hidingRe.test(cn) && !seen.has(el)) {
+            seen.add(el);
+          }
+        });
+
+        seen.forEach((el) => {
+          const elem = el as HTMLElement;
+          const cn = typeof elem.className === "string" ? elem.className : "";
+          const ariaHidden = elem.getAttribute("aria-hidden");
+          const role = elem.getAttribute("role") ?? "";
+          const tag = elem.tagName.toLowerCase();
+          const text = (elem.textContent ?? "").trim();
+          const hasDataDecorative = elem.hasAttribute("data-decorative");
+
+          const isDecorative =
+            ariaHidden === "true" ||
+            role === "presentation" ||
+            role === "none" ||
+            tag === "svg" ||
+            tag === "hr" ||
+            tag === "canvas" ||
+            tag === "path" ||
+            text === "" ||
+            decorativeRe.test(cn) ||
+            hasDataDecorative;
+
+          const isContent = !isDecorative && text.length > 0;
+
+          const hidingMatch = cn.match(hidingRe);
+          const hidingClass = hidingMatch ? hidingMatch[0] : null;
+
+          results.push({
+            selector: buildSel(el),
+            hidingClass,
+            isDecorative,
+            isContent,
+            className: cn,
+          });
+        });
+
+        return results;
+      },
+      {
+        hidingClassReStr: HIDING_CLASS_RE.source,
+        decorativeClassReStr: DECORATIVE_CLASS_RE.source,
+      }
+    );
+
+    if (candidateMetas.length === 0) {
+      warnings.push("No candidate elements found on the page.");
+    }
+
+    // ----- Step 2: for each breakpoint, evaluate visibility of each candidate -----
+    type BpVisibility = { breakpoint: number; visible: boolean };
+
+    const visibilityMatrix: BpVisibility[][] = [];
+
+    for (const bp of bps) {
+      await page.setViewportSize({ width: bp, height: viewportHeight });
+      // Small settle for layout recalculation
+      await page.waitForTimeout(120);
+
+      const selectors = candidateMetas.map((c) => c.selector);
+
+      const bpResults: boolean[] = await page.evaluate((sels: string[]) => {
+        return sels.map((sel) => {
+          let el: Element | null = null;
+          try {
+            el = document.querySelector(sel);
+          } catch {
+            return false;
+          }
+          if (!el) return false;
+          const elem = el as HTMLElement;
+          const style = window.getComputedStyle(elem);
+          if (style.display === "none") return false;
+          if (style.visibility === "hidden") return false;
+          if (parseFloat(style.opacity) === 0) return false;
+          const rect = elem.getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) return false;
+          return true;
+        });
+      }, selectors);
+
+      visibilityMatrix.push(
+        bpResults.map((visible, i) => ({ breakpoint: bps[i] ?? bp, visible }))
+      );
+    }
+
+    // ----- Step 3: assemble rows and flag -----
+    const flagged: VisibilityRow[] = [];
+
+    for (let i = 0; i < candidateMetas.length; i++) {
+      const meta = candidateMetas[i];
+      if (!meta) continue;
+
+      // visibilityMatrix is indexed [breakpointIndex][elementIndex]
+      // Reshape to per-element
+      const visibleAt: BpVisibility[] = bps.map((bp, bpIdx) => ({
+        breakpoint: bp,
+        visible: visibilityMatrix[bpIdx]?.[i]?.visible ?? false,
+      }));
+
+      const mobileVisible = visibleAt[0]?.visible ?? false;
+      const desktopVisible = visibleAt[visibleAt.length - 1]?.visible ?? false;
+
+      if (desktopVisible && !mobileVisible) {
+        const category: "intentional" | "likely-oversight" = meta.isDecorative
+          ? "intentional"
+          : "likely-oversight";
+
+        flagged.push({
+          selector: meta.selector,
+          hidingClass: meta.hidingClass,
+          isContent: meta.isContent,
+          isDecorative: meta.isDecorative,
+          visibleAt,
+          mobileVisible,
+          desktopVisible,
+          category,
+        });
+      }
+    }
+
+    const likely_oversight_count = flagged.filter(
+      (r) => r.category === "likely-oversight"
+    ).length;
+
+    return {
+      url,
+      breakpoints: bps,
+      flagged,
+      flagged_count: flagged.length,
+      likely_oversight_count,
+      warnings,
+    };
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+}

--- a/test/contrast.test.mjs
+++ b/test/contrast.test.mjs
@@ -1,0 +1,273 @@
+/**
+ * contrast.test.mjs
+ *
+ * Tests for the WCAG contrast audit module (dist/contrast.js).
+ * Runs after `npm run build` (tsc must have produced dist/contrast.js).
+ *
+ * Usage:  node --test test/
+ *   or:   node --test test/contrast.test.mjs
+ *
+ * Browser-dependent tests are skipped gracefully when Playwright / chromium
+ * is not installed — the Integrate phase installs chromium so CI runs all.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+// ── Resolve paths ────────────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distContrast = path.resolve(__dirname, '../dist/contrast.js');
+const fixturesDir = path.resolve(__dirname, 'fixtures');
+
+function fixtureUrl(name) {
+  return pathToFileURL(path.join(fixturesDir, name)).href;
+}
+
+// ── Load built module (fail gracefully if tsc hasn't run yet) ────────────────
+
+let contrastRatio;
+let relativeLuminance;
+let parseColor;
+let auditContrastSnapshot;
+let auditContrastUrl;
+let CaptureUnavailableError;
+
+try {
+  const mod = await import(distContrast);
+  contrastRatio = mod.contrastRatio;
+  relativeLuminance = mod.relativeLuminance;
+  parseColor = mod.parseColor;
+  auditContrastSnapshot = mod.auditContrastSnapshot;
+  auditContrastUrl = mod.auditContrastUrl;
+  // CaptureUnavailableError may be re-exported from contrast.ts or the error class itself
+  CaptureUnavailableError = mod.CaptureUnavailableError;
+} catch (err) {
+  const msg = `dist/contrast.js not found — run \`npm run build\` first. (${err.message})`;
+  test('contrast module available', (t) => { t.skip(msg); });
+  process.exit(0);
+}
+
+// ── Helper: skip a whole test if chromium is unavailable ────────────────────
+
+async function runOrSkip(t, fn) {
+  try {
+    await fn();
+  } catch (err) {
+    if (CaptureUnavailableError && err instanceof CaptureUnavailableError) {
+      t.skip(
+        'Playwright chromium not installed. ' +
+        'Run `npx playwright install chromium` then re-run tests. ' +
+        `(original message: ${err.message})`
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
+// ── Pure-function tests (no browser needed) ──────────────────────────────────
+
+test('contrastRatio(black, white) === 21 (±0.01)', () => {
+  const black = /** @type {[number,number,number]} */ ([0, 0, 0]);
+  const white = /** @type {[number,number,number]} */ ([255, 255, 255]);
+  const ratio = contrastRatio(black, white);
+  assert.ok(
+    Math.abs(ratio - 21) <= 0.01,
+    `expected contrastRatio([0,0,0],[255,255,255]) ≈ 21, got ${ratio}`
+  );
+});
+
+test('contrastRatio(white, white) === 1', () => {
+  const white = /** @type {[number,number,number]} */ ([255, 255, 255]);
+  const ratio = contrastRatio(white, white);
+  assert.ok(
+    Math.abs(ratio - 1) <= 0.01,
+    `expected contrastRatio([255,255,255],[255,255,255]) ≈ 1, got ${ratio}`
+  );
+});
+
+test('parseColor handles #hex shorthand', () => {
+  const [r, g, b, a] = parseColor('#fff');
+  assert.strictEqual(r, 255);
+  assert.strictEqual(g, 255);
+  assert.strictEqual(b, 255);
+  assert.ok(Math.abs(a - 1) < 0.001, 'alpha should be 1');
+});
+
+test('parseColor handles #rrggbb', () => {
+  const [r, g, b, a] = parseColor('#111111');
+  assert.strictEqual(r, 17);
+  assert.strictEqual(g, 17);
+  assert.strictEqual(b, 17);
+  assert.ok(Math.abs(a - 1) < 0.001);
+});
+
+test('parseColor handles rgb()', () => {
+  const [r, g, b, a] = parseColor('rgb(170, 170, 170)');
+  assert.strictEqual(r, 170);
+  assert.strictEqual(g, 170);
+  assert.strictEqual(b, 170);
+  assert.ok(Math.abs(a - 1) < 0.001);
+});
+
+test('parseColor handles rgba()', () => {
+  const [r, g, b, a] = parseColor('rgba(0,0,0,0.5)');
+  assert.strictEqual(r, 0);
+  assert.strictEqual(g, 0);
+  assert.strictEqual(b, 0);
+  assert.ok(Math.abs(a - 0.5) < 0.001);
+});
+
+test('parseColor handles named color "black"', () => {
+  const [r, g, b] = parseColor('black');
+  assert.strictEqual(r, 0);
+  assert.strictEqual(g, 0);
+  assert.strictEqual(b, 0);
+});
+
+test('parseColor handles named color "white"', () => {
+  const [r, g, b] = parseColor('white');
+  assert.strictEqual(r, 255);
+  assert.strictEqual(g, 255);
+  assert.strictEqual(b, 255);
+});
+
+test('parseColor handles "transparent"', () => {
+  const [r, g, b, a] = parseColor('transparent');
+  assert.strictEqual(a, 0);
+});
+
+test('relativeLuminance of white is 1', () => {
+  const lum = relativeLuminance([255, 255, 255]);
+  assert.ok(Math.abs(lum - 1) < 0.001, `expected ~1, got ${lum}`);
+});
+
+test('relativeLuminance of black is 0', () => {
+  const lum = relativeLuminance([0, 0, 0]);
+  assert.ok(Math.abs(lum - 0) < 0.001, `expected ~0, got ${lum}`);
+});
+
+// ── auditContrastSnapshot (pure — no browser) ────────────────────────────────
+
+test('auditContrastSnapshot: #111 on #fff passes AA', () => {
+  const result = auditContrastSnapshot([
+    { selector: 'p.passes', color: '#111111', bgColor: '#ffffff', fontPx: 16, bold: false, text: 'High contrast' },
+  ]);
+  assert.ok(result.rows.length >= 1, 'should have at least one row');
+  const row = result.rows.find((r) => r.selector === 'p.passes');
+  assert.ok(row !== undefined, 'row for p.passes should exist');
+  assert.strictEqual(row.aa, true, `#111 on #fff should pass AA (ratio was ${row.ratio})`);
+  assert.strictEqual(row.large, false, 'should not be large text at 16px normal weight');
+  assert.ok(row.ratio > 4.5, `ratio should exceed 4.5, got ${row.ratio}`);
+});
+
+test('auditContrastSnapshot: #aaa on #fff fails AA', () => {
+  const result = auditContrastSnapshot([
+    { selector: 'p.fails', color: '#aaaaaa', bgColor: '#ffffff', fontPx: 16, bold: false, text: 'Low contrast' },
+  ]);
+  assert.ok(result.rows.length >= 1, 'should have at least one row');
+  const row = result.rows.find((r) => r.selector === 'p.fails');
+  assert.ok(row !== undefined, 'row for p.fails should exist');
+  assert.strictEqual(row.aa, false, `#aaa on #fff should fail AA (ratio was ${row.ratio})`);
+  assert.ok(row.ratio < 4.5, `ratio should be below 4.5, got ${row.ratio}`);
+  assert.ok(row.delta_to_aa > 0, 'delta_to_aa should be positive for a failing element');
+});
+
+test('auditContrastSnapshot: large text (24px) has lower AA threshold (3:1)', () => {
+  const result = auditContrastSnapshot([
+    { selector: 'h2.large', color: '#767676', bgColor: '#ffffff', fontPx: 24, bold: false, text: 'Large text' },
+  ]);
+  const row = result.rows.find((r) => r.selector === 'h2.large');
+  assert.ok(row !== undefined, 'row for h2.large should exist');
+  assert.strictEqual(row.large, true, '24px should be large text');
+  assert.strictEqual(row.required_aa, 3, 'large text required AA ratio is 3:1');
+});
+
+test('auditContrastSnapshot: bold text ≥18.66px is large', () => {
+  const result = auditContrastSnapshot([
+    { selector: 'b.bold-large', color: '#000', bgColor: '#fff', fontPx: 18.66, bold: true, text: 'Bold large' },
+  ]);
+  const row = result.rows.find((r) => r.selector === 'b.bold-large');
+  assert.ok(row !== undefined, 'row should exist');
+  assert.strictEqual(row.large, true, '18.66px bold should be large text');
+});
+
+test('auditContrastSnapshot: aa_failures contains only failing rows', () => {
+  const result = auditContrastSnapshot([
+    { selector: 'p.ok', color: '#111', bgColor: '#fff', fontPx: 16 },
+    { selector: 'p.bad', color: '#aaa', bgColor: '#fff', fontPx: 16 },
+  ]);
+  assert.strictEqual(result.aa_fail_count, result.aa_failures.length, 'aa_fail_count matches aa_failures.length');
+  for (const row of result.aa_failures) {
+    assert.strictEqual(row.aa, false, `every aa_failure row must have aa===false, got ${row.ratio} for ${row.selector}`);
+  }
+});
+
+test('auditContrastSnapshot: result shape is complete', () => {
+  const result = auditContrastSnapshot([
+    { selector: 'x', color: '#aaa', bgColor: '#fff', fontPx: 16 },
+  ]);
+  const requiredKeys = ['total_text_elements', 'rows', 'aa_failures', 'aa_fail_count', 'warnings'];
+  for (const key of requiredKeys) {
+    assert.ok(key in result, `ContrastResult missing key: ${key}`);
+  }
+  assert.ok(Array.isArray(result.rows), 'rows is an array');
+  assert.ok(Array.isArray(result.aa_failures), 'aa_failures is an array');
+  assert.ok(Array.isArray(result.warnings), 'warnings is an array');
+  assert.strictEqual(result.total_text_elements, 1, 'total_text_elements should be 1');
+});
+
+// ── Browser-dependent tests ──────────────────────────────────────────────────
+
+test('auditContrastUrl: #111 text passes AA, #aaa text fails AA', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await auditContrastUrl(fixtureUrl('contrast.html'));
+
+    assert.ok(typeof result.total_text_elements === 'number', 'total_text_elements is a number');
+    assert.ok(result.total_text_elements >= 2, 'should find at least 2 text elements');
+    assert.ok(Array.isArray(result.rows), 'rows is an array');
+    assert.ok(result.aa_fail_count >= 1, `at least one AA failure expected, got ${result.aa_fail_count}`);
+
+    // Find the high-contrast element (color:#111)
+    const passingRow = result.rows.find(
+      (row) => row.foreground && (
+        row.foreground.includes('17, 17') ||  // rgb(17,17,17)
+        row.foreground === '#111111' ||
+        row.foreground === '#111'
+      )
+    );
+    // If colour-matching is imprecise, fall back to checking any row with aa===true exists
+    const anyPass = result.rows.some((row) => row.aa === true);
+    assert.ok(anyPass, 'at least one element should pass AA (the #111 text)');
+
+    // Find the low-contrast element (color:#aaa)
+    const anyFail = result.rows.some((row) => row.aa === false);
+    assert.ok(anyFail, 'at least one element should fail AA (the #aaa text)');
+  });
+});
+
+test('auditContrastUrl: result shape from live page', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await auditContrastUrl(fixtureUrl('contrast.html'));
+
+    const requiredKeys = ['total_text_elements', 'rows', 'aa_failures', 'aa_fail_count', 'warnings'];
+    for (const key of requiredKeys) {
+      assert.ok(key in result, `ContrastResult missing key: ${key}`);
+    }
+    assert.strictEqual(result.aa_fail_count, result.aa_failures.length, 'aa_fail_count matches aa_failures.length');
+
+    if (result.rows.length > 0) {
+      const row = result.rows[0];
+      const rowKeys = ['selector', 'foreground', 'background', 'fontPx', 'bold', 'large', 'ratio', 'aa', 'aaa', 'required_aa', 'delta_to_aa'];
+      for (const key of rowKeys) {
+        assert.ok(key in row, `ContrastRow missing key: ${key}`);
+      }
+      assert.ok(typeof row.ratio === 'number', 'ratio is a number');
+      assert.ok(row.ratio >= 1, 'ratio must be >= 1');
+      assert.ok(row.ratio <= 21.1, 'ratio must be <= 21');
+    }
+  });
+});

--- a/test/fixtures/contrast.html
+++ b/test/fixtures/contrast.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Contrast Fixture</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 24px;
+      background-color: #ffffff;
+      font-family: sans-serif;
+      font-size: 16px;
+    }
+    /* #111 on #fff: contrast ratio ~18.1:1 — passes AA (4.5:1) and AAA (7:1) */
+    .passes-aa {
+      color: #111111;
+      background-color: #ffffff;
+      font-size: 16px;
+      font-weight: 400;
+    }
+    /* #aaa on #fff: contrast ratio ~2.32:1 — FAILS AA (needs 4.5:1) */
+    .fails-aa {
+      color: #aaaaaa;
+      background-color: #ffffff;
+      font-size: 16px;
+      font-weight: 400;
+    }
+  </style>
+</head>
+<body>
+  <p class="passes-aa" data-testid="passes-aa">High contrast text — passes AA</p>
+  <p class="fails-aa" data-testid="fails-aa">Low contrast text — fails AA</p>
+</body>
+</html>

--- a/test/fixtures/responsive.html
+++ b/test/fixtures/responsive.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Responsive Visibility Fixture</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; background: #fff; color: #111; }
+
+    /* Base: hidden elements are display:none */
+    .hidden { display: none; }
+
+    /* At md (768px+): hidden md:block elements become block */
+    @media (min-width: 768px) {
+      .hidden.md\:block { display: block; }
+    }
+  </style>
+</head>
+<body>
+  <!-- Always-visible heading — should NOT be flagged -->
+  <h1 data-testid="heading">Page Heading</h1>
+
+  <!--
+    CONTENT lede: hidden on mobile (390px → display:none), visible at desktop (1440px → display:block).
+    This is a likely-oversight: real text content invisible on mobile.
+  -->
+  <p class="hidden md:block" data-testid="lede" data-lede>Serif lede copy</p>
+
+  <!--
+    DECORATIVE element: same responsive hiding pattern, but aria-hidden and empty.
+    This should be categorised as "intentional" (decorative hidden on mobile is fine).
+  -->
+  <div class="hidden md:block" aria-hidden="true" data-testid="decoration"></div>
+</body>
+</html>

--- a/test/responsive.test.mjs
+++ b/test/responsive.test.mjs
@@ -1,0 +1,165 @@
+/**
+ * responsive.test.mjs
+ *
+ * Tests for the responsive visibility audit module (dist/responsive.js).
+ * Runs after `npm run build` (tsc must have produced dist/responsive.js).
+ *
+ * Usage:  node --test test/
+ *   or:   node --test test/responsive.test.mjs
+ *
+ * If Playwright / chromium is not installed the browser-dependent tests are
+ * skipped with a clear diagnostic — the Integrate phase installs chromium so
+ * CI will exercise the full suite.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+// ── Resolve paths ────────────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distResponsive = path.resolve(__dirname, '../dist/responsive.js');
+const fixturesDir = path.resolve(__dirname, 'fixtures');
+
+function fixtureUrl(name) {
+  return pathToFileURL(path.join(fixturesDir, name)).href;
+}
+
+// ── Load built module (fail gracefully if tsc hasn't run yet) ────────────────
+
+let captureResponsiveVisibility;
+let CaptureUnavailableError;
+
+try {
+  const mod = await import(distResponsive);
+  captureResponsiveVisibility = mod.captureResponsiveVisibility;
+  CaptureUnavailableError = mod.CaptureUnavailableError;
+} catch (err) {
+  const msg = `dist/responsive.js not found — run \`npm run build\` first. (${err.message})`;
+  test('responsive module available', (t) => { t.skip(msg); });
+  process.exit(0);
+}
+
+// ── Helper: skip a whole test if chromium is unavailable ────────────────────
+
+async function runOrSkip(t, fn) {
+  try {
+    await fn();
+  } catch (err) {
+    if (CaptureUnavailableError && err instanceof CaptureUnavailableError) {
+      t.skip(
+        'Playwright chromium not installed. ' +
+        'Run `npx playwright install chromium` then re-run tests. ' +
+        `(original message: ${err.message})`
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test('lede paragraph is flagged as likely-oversight', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await captureResponsiveVisibility(
+      fixtureUrl('responsive.html'),
+      [390, 768, 1440, 2160]
+    );
+
+    assert.ok(Array.isArray(result.flagged), 'flagged is an array');
+    assert.ok(typeof result.flagged_count === 'number', 'flagged_count is a number');
+    assert.ok(typeof result.likely_oversight_count === 'number', 'likely_oversight_count is a number');
+
+    // The lede <p> must appear in flagged as likely-oversight
+    const ledeRow = result.flagged.find(
+      (row) =>
+        row.selector.includes('lede') ||
+        (row.selector.includes('p') && !row.isDecorative)
+    );
+    assert.ok(ledeRow !== undefined, 'lede paragraph must appear in flagged rows');
+    assert.strictEqual(
+      ledeRow.category,
+      'likely-oversight',
+      'lede paragraph must be categorised as likely-oversight'
+    );
+    assert.strictEqual(ledeRow.mobileVisible, false, 'lede must be hidden at mobile breakpoint');
+    assert.strictEqual(ledeRow.desktopVisible, true, 'lede must be visible at desktop breakpoint');
+
+    assert.ok(result.likely_oversight_count >= 1, 'at least one likely-oversight element found');
+  });
+});
+
+test('decorative element is NOT flagged as likely-oversight', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await captureResponsiveVisibility(
+      fixtureUrl('responsive.html'),
+      [390, 768, 1440, 2160]
+    );
+
+    // If the decoration div appears in flagged, it must NOT be likely-oversight
+    const decorationRows = result.flagged.filter(
+      (row) =>
+        row.selector.includes('decoration') ||
+        (row.isDecorative === true)
+    );
+
+    for (const row of decorationRows) {
+      assert.notStrictEqual(
+        row.category,
+        'likely-oversight',
+        `decorative element at selector "${row.selector}" must not be categorised as likely-oversight`
+      );
+    }
+  });
+});
+
+test('h1 heading is not flagged (always visible)', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await captureResponsiveVisibility(
+      fixtureUrl('responsive.html'),
+      [390, 768, 1440, 2160]
+    );
+
+    // The always-visible h1 should not appear in flagged
+    const h1Row = result.flagged.find(
+      (row) => row.selector.startsWith('h1') || row.selector.includes('[data-testid="heading"]')
+    );
+    assert.strictEqual(
+      h1Row,
+      undefined,
+      'the always-visible h1 heading must not appear in the flagged list'
+    );
+  });
+});
+
+test('result shape is complete', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await captureResponsiveVisibility(
+      fixtureUrl('responsive.html'),
+      [390, 1440]
+    );
+
+    assert.ok(typeof result.url === 'string', 'url is a string');
+    assert.ok(Array.isArray(result.breakpoints), 'breakpoints is an array');
+    assert.ok(Array.isArray(result.flagged), 'flagged is an array');
+    assert.ok(typeof result.flagged_count === 'number', 'flagged_count is a number');
+    assert.ok(typeof result.likely_oversight_count === 'number', 'likely_oversight_count is a number');
+    assert.ok(Array.isArray(result.warnings), 'warnings is an array');
+    assert.strictEqual(result.flagged.length, result.flagged_count, 'flagged_count matches flagged.length');
+
+    if (result.flagged.length > 0) {
+      const row = result.flagged[0];
+      const requiredRowKeys = [
+        'selector', 'hidingClass', 'isContent', 'isDecorative',
+        'visibleAt', 'mobileVisible', 'desktopVisible', 'category',
+      ];
+      for (const key of requiredRowKeys) {
+        assert.ok(key in row, `VisibilityRow missing key: ${key}`);
+      }
+      assert.ok(Array.isArray(row.visibleAt), 'visibleAt is an array');
+    }
+  });
+});


### PR DESCRIPTION
audit_responsive_visibility(url, breakpoints=[390,768,1440,2160]): renders the page at each breakpoint and computes per-element visibility (display:none / opacity:0 / visibility:hidden / zero-size). Flags content elements visible on desktop but hidden on mobile and categorises each as likely-oversight (content that vanishes on mobile) vs intentional (decorative — aria-hidden, empty, or decorative class). Returns a table: selector / hiding-class / mobile-visible / desktop-visible / category. Catches the hidden-on-mobile content bug class.

audit_contrast(url | dom_snapshot): computes WCAG contrast ratios for every text element from the computed DOM (foreground color + composited ancestor background), reports AA (4.5:1 / 3:1 large) and AAA pass/fail per element, and surfaces failing pairs with selector, ratio, and delta-to-pass. Pure WCAG math (parseColor/relativeLuminance/contrastRatio) is exported and unit-tested.

New modules src/responsive.ts + src/contrast.ts (own lazy Playwright import, no new dependency). New tools only — no existing tool behavior changes. node:test suites cover the lede-vs-decorative categorisation and the AA pass/fail logic.


Claude-Session: https://claude.ai/code/session_01W7Rvt13m8nK21EQfKFHkiV