### PR TITLE
Add interactions[] to audit_page + audit_asset_integrity tool

### DIFF
--- a/src/asset-integrity.ts
+++ b/src/asset-integrity.ts
@@ -1,0 +1,163 @@
+import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+
+export type AssetIntegrityResult = {
+  path: string;
+  bottom_variance: number;
+  verdict: "clean" | "likely-sliced";
+  confidence: number;
+  warnings: string[];
+};
+
+export type AssetIntegrityOptions = {
+  bottomFraction?: number;
+  minRows?: number;
+  varianceThreshold?: number;
+};
+
+type DecodedPng = {
+  width: number;
+  height: number;
+  data: Uint8Array;
+};
+
+type PngModule = {
+  PNG?: {
+    sync?: {
+      read?: (buffer: Buffer) => DecodedPng;
+    };
+  };
+};
+
+const DATA_URL_PREFIX = /^data:image\/png;base64,/i;
+
+export async function auditAssetIntegrity(
+  imagePaths: string[],
+  opts: AssetIntegrityOptions = {}
+): Promise<AssetIntegrityResult[]> {
+  // @ts-ignore pngjs is intentionally optional; absence falls back to clean-with-warning.
+  const pngMod = (await import("pngjs").catch(() => null)) as PngModule | null;
+  const PNG = pngMod?.PNG;
+  const readPng = PNG?.sync?.read;
+
+  return imagePaths.map(function (imagePath) {
+    let buffer: Buffer;
+
+    try {
+      buffer = readFileSync(imagePath);
+    } catch (error) {
+      return fallbackResult(imagePath, [
+        "Could not read file: " + errorMessage(error)
+      ]);
+    }
+
+    if (!readPng) {
+      return fallbackResult(imagePath, [
+        "pngjs not installed — cannot analyze asset integrity"
+      ]);
+    }
+
+    try {
+      return auditPng(imagePath, readPng(buffer), opts);
+    } catch (error) {
+      return fallbackResult(imagePath, [
+        "Failed to decode PNG: " + errorMessage(error)
+      ]);
+    }
+  });
+}
+
+function stripPngPrefix(base64: string): string {
+  return base64.replace(DATA_URL_PREFIX, "");
+}
+
+function fallbackResult(path: string, warnings: string[]): AssetIntegrityResult {
+  return {
+    path,
+    bottom_variance: 0,
+    verdict: "clean",
+    confidence: 0,
+    warnings
+  };
+}
+
+function auditPng(
+  path: string,
+  png: DecodedPng,
+  opts: AssetIntegrityOptions
+): AssetIntegrityResult {
+  const threshold = opts.varianceThreshold ?? 100;
+  const bottomFraction = opts.bottomFraction ?? 0.05;
+  const minRows = opts.minRows ?? 20;
+  const stripHeight = Math.min(
+    png.height,
+    Math.max(minRows, Math.round(png.height * bottomFraction))
+  );
+  const bottomVariance = bottomLuminanceVariance(png, stripHeight);
+  const verdict = bottomVariance > threshold ? "likely-sliced" : "clean";
+
+  // Confidence is monotonic around the variance threshold: clean approaches 1 as
+  // variance approaches 0; likely-sliced starts at 0.5 and approaches 1 by 4x threshold.
+  const confidence =
+    verdict === "clean"
+      ? clamp(1 - bottomVariance / threshold, 0, 1)
+      : Math.max(0.5, clamp(bottomVariance / (threshold * 4), 0, 1));
+
+  return {
+    path,
+    bottom_variance: bottomVariance,
+    verdict,
+    confidence,
+    warnings: []
+  };
+}
+
+function bottomLuminanceVariance(png: DecodedPng, stripHeight: number): number {
+  const startY = png.height - stripHeight;
+  const pixelCount = png.width * stripHeight;
+
+  if (pixelCount <= 0) {
+    return 0;
+  }
+
+  let lumaTotal = 0;
+  const luminances: number[] = [];
+
+  for (let y = startY; y < png.height; y += 1) {
+    for (let x = 0; x < png.width; x += 1) {
+      const index = (y * png.width + x) * 4;
+      const r = png.data[index];
+      const g = png.data[index + 1];
+      const b = png.data[index + 2];
+      const luminance = pixelLuminance(r, g, b);
+
+      luminances.push(luminance);
+      lumaTotal += luminance;
+    }
+  }
+
+  const mean = lumaTotal / pixelCount;
+  let squaredDeltaTotal = 0;
+
+  for (let i = 0; i < luminances.length; i += 1) {
+    const delta = luminances[i] - mean;
+    squaredDeltaTotal += delta * delta;
+  }
+
+  return squaredDeltaTotal / pixelCount;
+}
+
+function pixelLuminance(r: number, g: number, b: number): number {
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -25,6 +25,9 @@ type PageLike = {
   content: () => Promise<string>;
   evaluate: <T>(fn: (arg?: any) => T | Promise<T>, arg?: any) => Promise<T>;
   goto: (url: string, options: { waitUntil: "load"; timeout: number }) => Promise<unknown>;
+  hover: (selector: string, options?: { timeout?: number }) => Promise<void>;
+  click: (selector: string, options?: { timeout?: number }) => Promise<void>;
+  focus: (selector: string, options?: { timeout?: number }) => Promise<void>;
   screenshot: (options: { fullPage: boolean }) => Promise<Buffer>;
   setViewportSize: (viewport: { width: number; height: number }) => Promise<void>;
   waitForFunction: (
@@ -60,7 +63,10 @@ export type CaptureResult = {
   warnings: string[];
 };
 
+export type Interaction = { selector: string; event: "hover" | "click" | "focus"; delay_ms: number };
+
 export type CaptureOptions = {
+  interactions?: Interaction[];
   scroll_settle?: boolean;
   viewport?: { w: number; h: number };
   timeoutMs?: number;
@@ -78,7 +84,14 @@ export async function capturePage(url: string, opts?: CaptureOptions): Promise<C
       const chromium = await loadChromium();
       browser = await chromium.launch({ headless: true });
     } catch (error) {
-      const fallback = captureFileUrlWithoutBrowser(url, viewport, scrollSettle, warnings, error);
+      const fallback = captureFileUrlWithoutBrowser(
+        url,
+        viewport,
+        scrollSettle,
+        opts && Array.isArray(opts.interactions) ? opts.interactions : [],
+        warnings,
+        error
+      );
       if (fallback !== null) {
         return fallback;
       }
@@ -114,6 +127,31 @@ export async function capturePage(url: string, opts?: CaptureOptions): Promise<C
       await page.waitForTimeout(300);
       scrolledToBottom = true;
       videoArtifacts = await detectVideoArtifacts(page, warnings);
+    }
+
+    const interactions = opts && Array.isArray(opts.interactions) ? opts.interactions : [];
+    for (const interaction of interactions) {
+      const selector = interaction.selector;
+      const event = interaction.event;
+      const delayMs = typeof interaction.delay_ms === "number" ? interaction.delay_ms : 0;
+
+      try {
+        if (event === "hover") {
+          await page.hover(selector, { timeout: timeoutMs });
+        } else if (event === "click") {
+          await page.click(selector, { timeout: timeoutMs });
+        } else if (event === "focus") {
+          await page.focus(selector, { timeout: timeoutMs });
+        } else {
+          warnings.push("Unknown interaction event: " + event);
+          await page.waitForTimeout(delayMs);
+          continue;
+        }
+      } catch (error) {
+        warnings.push("Interaction failed (" + event + " " + selector + "): " + errorMessage(error));
+      }
+
+      await page.waitForTimeout(delayMs);
     }
 
     const renderedHtml = await page.content();
@@ -195,6 +233,7 @@ function captureFileUrlWithoutBrowser(
   url: string,
   viewport: { w: number; h: number },
   scrollSettle: boolean,
+  interactions: Interaction[],
   warnings: string[],
   launchError: unknown
 ): CaptureResult | null {
@@ -211,6 +250,9 @@ function captureFileUrlWithoutBrowser(
   }
 
   warnings.push("Browser launch failed; used file URL fallback: " + errorMessage(launchError));
+  if (interactions.length > 0) {
+    warnings.push("Interactions skipped: browser unavailable (file:// fallback)");
+  }
 
   const renderedHtml = scrollSettle ? applyScrollSettleFallback(html) : html;
   return {

--- a/src/contrast.ts
+++ b/src/contrast.ts
@@ -6,6 +6,8 @@
 
 import { CaptureUnavailableError } from "./capture.js";
 
+export { CaptureUnavailableError };
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -236,10 +238,18 @@ export async function auditContrastUrl(
     );
   }
 
-  const browser = await chromium.launch({ headless: true });
+  let browser: import("playwright").Browser | null = null;
   const warnings: string[] = [];
 
   try {
+    try {
+      browser = await chromium.launch({ headless: true });
+    } catch {
+      throw new CaptureUnavailableError(
+        "Playwright chromium not available. Run: npx playwright install chromium"
+      );
+    }
+
     const page = await browser.newPage();
     await page.setViewportSize({
       width: opts?.viewport?.w ?? 1440,
@@ -361,6 +371,8 @@ export async function auditContrastUrl(
     result.warnings.push(...warnings);
     return result;
   } finally {
-    await browser.close();
+    if (browser) {
+      await browser.close();
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type { VerifiableFinding } from "./capture.js";
 import { captureResponsiveVisibility } from "./responsive.js";
 import { auditContrastUrl, auditContrastSnapshot } from "./contrast.js";
 import { diffScreenshots } from "./image-diff.js";
+import { auditAssetIntegrity } from "./asset-integrity.js";
 
 // ── Path setup ──────────────────────────────────────────────────────
 
@@ -2244,12 +2245,17 @@ server.tool(
     html: z.string().optional().describe("The full HTML content of the page to audit"),
     url: z.string().optional().describe("If set, Raven launches headless chromium, renders the page, and audits the RENDERED DOM."),
     scroll_settle: z.boolean().optional().describe("Before capturing, scroll to bottom and settle IntersectionObserver/whileInView reveals (300ms), and play preload=none videos. Prevents blank-section false positives."),
+    interactions: z.array(z.object({
+      selector: z.string(),
+      event: z.enum(["hover", "click", "focus"]),
+      delay_ms: z.number()
+    })).optional().describe("Before capturing, fire each interaction in order (hover/click/focus the selector, then wait delay_ms). Captures the resulting dynamic state — e.g. an on-hover theme-toggle wash invisible to a static screenshot."),
     viewport: z.object({ w: z.number(), h: z.number() }).optional(),
     strict: z.boolean().optional().describe("Strict mode — also flags warnings as failures. Default: false"),
     containerMaxWidth: z.number().optional().describe("Your design system's canonical content-container width in px (e.g. 1152). When set, the responsive/max-width check flags divergence from this token instead of using the generic 1200px heuristic."),
     adversarial_verify: z.boolean().optional().describe("After generating findings, independently re-check each against the live DOM/network and tag it confirmed / likely-artifact / inconclusive. Surfaces a debunked_count.")
   },
-  async function({ html, url, scroll_settle, viewport, strict, containerMaxWidth, adversarial_verify }) {
+  async function({ html, url, scroll_settle, interactions, viewport, strict, containerMaxWidth, adversarial_verify }) {
     var issues: Array<{ severity: "error" | "warning"; rule: string; message: string; fix: string }> = [];
     var passes: string[] = [];
     var capMeta: any = null;
@@ -2258,7 +2264,7 @@ server.tool(
 
     if (url !== undefined && url !== null) {
       try {
-        var cap = await capturePage(url, { scroll_settle: scroll_settle, viewport: viewport });
+        var cap = await capturePage(url, { scroll_settle: scroll_settle, interactions: interactions, viewport: viewport });
         html = cap.renderedHtml;
         capMeta = { url: url, viewport: cap.viewport, scrolledToBottom: cap.scrolledToBottom, screenshot_bytes: cap.screenshotBase64 };
         if (cap.videoArtifacts !== undefined && cap.videoArtifacts !== null) {
@@ -2596,6 +2602,16 @@ server.tool(
         text: JSON.stringify(result, null, 2)
       }]
     };
+  }
+);
+
+server.tool(
+  "audit_asset_integrity",
+  "Detect PNG exports whose content is sliced/cut off at the bottom edge (e.g. a Figma export that ended mid-form). Dimension/ratio checks cannot catch cut content inside a correctly-sized file; this measures per-pixel luminance variance in the bottom strip — uniform background = clean, high-variance UI content running into the edge = likely-sliced. Accepts filesystem paths to PNGs.",
+  { image_paths: z.array(z.string()).describe("Filesystem paths to PNG files to check for sliced/cut-off bottom content.") },
+  async function({ image_paths }) {
+    var results = await auditAssetIntegrity(image_paths || []);
+    return { content: [{ type: "text" as const, text: JSON.stringify({ tool: "audit_asset_integrity", results: results }, null, 2) }] };
   }
 );
 

--- a/src/responsive.ts
+++ b/src/responsive.ts
@@ -6,6 +6,8 @@
 
 import { CaptureUnavailableError } from "./capture.js";
 
+export { CaptureUnavailableError };
+
 export type VisibilityRow = {
   selector: string;
   hidingClass: string | null;

--- a/test/assetintegrity.test.mjs
+++ b/test/assetintegrity.test.mjs
@@ -1,0 +1,177 @@
+/**
+ * assetintegrity.test.mjs
+ *
+ * Tests for auditAssetIntegrity() in dist/asset-integrity.js.
+ * Runs after `npm run build` (tsc must have produced dist/asset-integrity.js).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distAssetIntegrity = path.resolve(__dirname, '../dist/asset-integrity.js');
+
+let auditAssetIntegrity;
+
+try {
+  const mod = await import(distAssetIntegrity);
+  auditAssetIntegrity = mod.auditAssetIntegrity;
+} catch (err) {
+  const msg = `dist/asset-integrity.js not found - run \`npm run build\` first. (${err.message})`;
+  test('asset-integrity module available', (t) => { t.skip(msg); });
+  process.exit(0);
+}
+
+let PNG;
+try {
+  const pngjs = await import('pngjs');
+  PNG = pngjs.PNG;
+} catch (err) {
+  test('pngjs available for test PNG generation', (t) => {
+    t.skip(`pngjs not installed - cannot build synthetic PNGs for asset-integrity tests. (${err.message})`);
+  });
+  process.exit(0);
+}
+
+function makeCleanPng() {
+  const width = 200;
+  const height = 200;
+  const png = new PNG({ width, height });
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = (width * y + x) * 4;
+
+      if (y >= 180) {
+        png.data[idx + 0] = 204;
+        png.data[idx + 1] = 204;
+        png.data[idx + 2] = 204;
+      } else {
+        png.data[idx + 0] = (x * 3 + y) % 256;
+        png.data[idx + 1] = (x + y * 2) % 256;
+        png.data[idx + 2] = (x * 5 + y * 7) % 256;
+      }
+
+      png.data[idx + 3] = 255;
+    }
+  }
+
+  return png;
+}
+
+function makeSlicedPng() {
+  const width = 200;
+  const height = 200;
+  const png = new PNG({ width, height });
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = (width * y + x) * 4;
+
+      if (y >= 180) {
+        const channel = x % 2 === 0 ? 0 : 255;
+        png.data[idx + 0] = channel;
+        png.data[idx + 1] = channel;
+        png.data[idx + 2] = channel;
+      } else {
+        png.data[idx + 0] = (x * 3 + y) % 256;
+        png.data[idx + 1] = (x + y * 2) % 256;
+        png.data[idx + 2] = (x * 5 + y * 7) % 256;
+      }
+
+      png.data[idx + 3] = 255;
+    }
+  }
+
+  return png;
+}
+
+async function writePackedPng(filePath, png) {
+  const pngBuffer = await pngToBuffer(png);
+  await writeFile(filePath, pngBuffer);
+}
+
+function pngToBuffer(png) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    const stream = png.pack();
+
+    stream.on('data', (chunk) => {
+      chunks.push(Buffer.from(chunk));
+    });
+    stream.on('end', () => {
+      resolve(Buffer.concat(chunks));
+    });
+    stream.on('error', reject);
+  });
+}
+
+function bottomVarianceFromResultOrPng(result, png) {
+  if (result && typeof result.bottom_variance === 'number') {
+    return result.bottom_variance;
+  }
+
+  return bottomLuminanceVariance(png, 20);
+}
+
+function bottomLuminanceVariance(png, stripHeight) {
+  const startY = png.height - stripHeight;
+  const pixelCount = png.width * stripHeight;
+  let lumaTotal = 0;
+  const luminances = [];
+
+  for (let y = startY; y < png.height; y += 1) {
+    for (let x = 0; x < png.width; x += 1) {
+      const idx = (png.width * y + x) * 4;
+      const luminance =
+        0.2126 * png.data[idx + 0] +
+        0.7152 * png.data[idx + 1] +
+        0.0722 * png.data[idx + 2];
+
+      luminances.push(luminance);
+      lumaTotal += luminance;
+    }
+  }
+
+  const mean = lumaTotal / pixelCount;
+  let squaredDeltaTotal = 0;
+
+  for (let i = 0; i < luminances.length; i += 1) {
+    const delta = luminances[i] - mean;
+    squaredDeltaTotal += delta * delta;
+  }
+
+  return squaredDeltaTotal / pixelCount;
+}
+
+test('asset integrity distinguishes uniform bottom strip from sliced bottom strip', async (t) => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'raven-assetintegrity-'));
+  const cleanPath = path.join(dir, 'clean.png');
+  const slicedPath = path.join(dir, 'sliced.png');
+  const cleanPng = makeCleanPng();
+  const slicedPng = makeSlicedPng();
+
+  await writePackedPng(cleanPath, cleanPng);
+  await writePackedPng(slicedPath, slicedPng);
+
+  const results = await auditAssetIntegrity([cleanPath, slicedPath]);
+  const clean = results.find((result) => result.path === cleanPath);
+  const sliced = results.find((result) => result.path === slicedPath);
+
+  assert.ok(clean, 'clean result is present');
+  assert.ok(sliced, 'sliced result is present');
+
+  const cleanVariance = bottomVarianceFromResultOrPng(clean, cleanPng);
+  const slicedVariance = bottomVarianceFromResultOrPng(sliced, slicedPng);
+  t.diagnostic(`clean bottom variance: ${cleanVariance.toFixed(4)}`);
+  t.diagnostic(`sliced bottom variance: ${slicedVariance.toFixed(4)}`);
+
+  assert.strictEqual(clean.verdict, 'clean');
+  assert.strictEqual(sliced.verdict, 'likely-sliced');
+  assert.ok(slicedVariance > cleanVariance, 'sliced bottom variance should exceed clean bottom variance');
+});

--- a/test/fixtures/theme-wipe.html
+++ b/test/fixtures/theme-wipe.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Theme wipe fixture</title>
+  <style>
+    html,
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #101014;
+    }
+
+    body {
+      display: grid;
+      place-items: center;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    .theme-fab {
+      position: relative;
+      z-index: 2;
+      appearance: none;
+      border: 1px solid #5f5f70;
+      border-radius: 999px;
+      background: #242430;
+      color: #f4f4ff;
+      cursor: pointer;
+      font: inherit;
+      padding: 12px 18px;
+    }
+
+    .theme-fab:hover ~ .wash {
+      opacity: 1;
+    }
+
+    .wash {
+      position: fixed;
+      inset: 0;
+      background: #fff;
+      opacity: 0;
+      transition: none;
+      pointer-events: none;
+      z-index: 1;
+    }
+  </style>
+</head>
+<body>
+  <button class="theme-fab">theme</button>
+  <div class="wash" aria-hidden="true"></div>
+</body>
+</html>

--- a/test/interactions.test.mjs
+++ b/test/interactions.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * interactions.test.mjs
+ *
+ * Tests for interaction replay in dist/capture.js.
+ * Runs after `npm run build` (tsc must have produced dist/capture.js).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distCapture = path.resolve(__dirname, '../dist/capture.js');
+const fixturesDir = path.resolve(__dirname, 'fixtures');
+const EMPTY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+function fixtureUrl(name) {
+  return pathToFileURL(path.join(fixturesDir, name)).href;
+}
+
+let capturePage;
+let CaptureUnavailableError;
+
+try {
+  const mod = await import(distCapture);
+  capturePage = mod.capturePage;
+  CaptureUnavailableError = mod.CaptureUnavailableError;
+} catch (err) {
+  const msg = `dist/capture.js not found - run \`npm run build\` first. (${err.message})`;
+  test('capture module available', (t) => { t.skip(msg); });
+  process.exit(0);
+}
+
+let PNG;
+try {
+  const pngjs = await import('pngjs');
+  PNG = pngjs.PNG;
+} catch (err) {
+  test('pngjs available for screenshot decoding', (t) => {
+    t.skip(`pngjs not installed - cannot decode screenshots for interaction tests. (${err.message})`);
+  });
+  process.exit(0);
+}
+
+async function runOrSkip(t, fn) {
+  try {
+    await fn();
+  } catch (err) {
+    if (CaptureUnavailableError && err instanceof CaptureUnavailableError) {
+      t.skip(
+        'Playwright chromium not installed. ' +
+        'Run `npx playwright install chromium` then re-run tests. ' +
+        `(original message: ${err.message})`
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
+function decodeScreenshotOrSkip(t, base64) {
+  if (base64 === EMPTY_PNG_BASE64) {
+    t.skip('capture returned the 1x1 EMPTY_PNG fallback; browser unavailable for pixel assertion.');
+    return null;
+  }
+
+  const png = PNG.sync.read(Buffer.from(base64, 'base64'));
+
+  if (png.width === 1 && png.height === 1) {
+    t.skip('capture returned the 1x1 EMPTY_PNG fallback; browser unavailable for pixel assertion.');
+    return null;
+  }
+
+  return png;
+}
+
+function nearWhiteFraction(png) {
+  const total = png.width * png.height;
+  let nearWhite = 0;
+
+  for (let y = 0; y < png.height; y += 1) {
+    for (let x = 0; x < png.width; x += 1) {
+      const idx = (png.width * y + x) * 4;
+      const r = png.data[idx + 0];
+      const g = png.data[idx + 1];
+      const b = png.data[idx + 2];
+
+      if (r > 235 && g > 235 && b > 235) {
+        nearWhite += 1;
+      }
+    }
+  }
+
+  return nearWhite / total;
+}
+
+test('hover interaction triggers the full-viewport white theme wash', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await capturePage(fixtureUrl('theme-wipe.html'), {
+      interactions: [{ selector: '.theme-fab', event: 'hover', delay_ms: 200 }],
+    });
+
+    const png = decodeScreenshotOrSkip(t, result.screenshotBase64);
+    if (png === null) {
+      return;
+    }
+
+    const fraction = nearWhiteFraction(png);
+    t.diagnostic(`near-white fraction after hover: ${fraction.toFixed(4)}`);
+    assert.ok(fraction > 0.6, `near-white fraction should be > 0.6 after hover, got ${fraction}`);
+  });
+});
+
+test('without interactions the theme wash stays hidden', async (t) => {
+  await runOrSkip(t, async () => {
+    const result = await capturePage(fixtureUrl('theme-wipe.html'));
+
+    const png = decodeScreenshotOrSkip(t, result.screenshotBase64);
+    if (png === null) {
+      return;
+    }
+
+    const fraction = nearWhiteFraction(png);
+    t.diagnostic(`near-white fraction without interactions: ${fraction.toFixed(4)}`);
+    assert.ok(fraction < 0.2, `near-white fraction should be < 0.2 without interactions, got ${fraction}`);
+  });
+});


### PR DESCRIPTION
## What

**1. `interactions[]` on `audit_page`** — an optional array of `{ selector, event, delay_ms }` fired in order (`hover`/`click`/`focus` via native Playwright, so real CSS `:hover`/`:focus` pseudo-classes trigger) after scroll-settle and before the screenshot. Transient/dynamic visual states — e.g. an on-hover theme-toggle white wash — are now photographed, where a settled static screenshot showed nothing.

**2. New `audit_asset_integrity` tool** — given PNG paths, measures per-pixel luminance variance in the bottom strip (5% height, min 20px) and flags high-variance bottom rows as `likely-sliced`. Catches content cut off *inside* a correctly-sized export, which dimension/ratio checks cannot detect.

## Why

Two recurring verification gaps: dynamic defects (hover/transition) invisible to static capture, and sliced asset exports passing ratio math while content was cut. Both cost real debugging time.

## Backwards compatibility

- `interactions` is optional — absent ⇒ byte-identical to today.
- `audit_asset_integrity` is purely additive.
- `contrast.ts`/`responsive.ts` gain graceful degradation when Chromium is absent.

## Verification (eyes-on, real Chromium)

| Check | Result |
|---|---|
| hover photographs on-hover state | ✓ 99.8% white wash captured |
| baseline (no interaction) not washed | ✓ 0.0% white |
| sliced PNG → `likely-sliced` | ✓ variance 16256, conf 1.00 |
| clean PNG → `clean` | ✓ variance 0.0, conf 1.00 |
| `tsc` + full `node --test` suite | ✓ 33 pass / 8 skip / 0 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)